### PR TITLE
explicitly list PLANNER_APPS for wcoa in settings.py and ensure 'surv…

### DIFF
--- a/wcoa/settings.py
+++ b/wcoa/settings.py
@@ -83,6 +83,14 @@ WAGTAILADMIN_BASE_URL = 'http://localhost:8001'
 
 DB_CHANNEL = 'wcoaportal'
 
+# Defines which apps/modules interact with the MyPlanner tab in mp-visualize's left nav
+# see https://github.com/Ecotrust/mp-visualize/wiki for more info
+PLANNER_APPS = [
+    'visualize',
+    'drawing',
+    'survey',
+]
+
 try:
     from .local_settings import *
 except ImportError:


### PR DESCRIPTION
…ey' is included

RESULT: if a current survey is associated with a group a user belongs to, the user should see that survey in their 'MyPlanner' tab:

<img width="578" height="428" alt="image" src="https://github.com/user-attachments/assets/f329d3b8-7443-4b5f-8afc-172c5e2c5e4c" />
